### PR TITLE
[AC-6732] Sub nav items display program abbreviation

### DIFF
--- a/src/themes/masschallenge/collections/menu.overrides
+++ b/src/themes/masschallenge/collections/menu.overrides
@@ -68,7 +68,7 @@
 	background: transparent;
 	border: 0;
 	z-index: auto;
-	padding:0 2em;
+	padding:0 1.6em;
 	width: auto;
 	font-weight: normal;
 }

--- a/src/themes/masschallenge/collections/menu.overrides
+++ b/src/themes/masschallenge/collections/menu.overrides
@@ -63,4 +63,12 @@
 	left: 70px;
 }
 
-
+.ui.scrollable.menu .item > .basic.corner.label {
+	color: rgba(0,0,0,.60);
+	background: transparent;
+	border: 0;
+	z-index: auto;
+	padding:0 2em;
+	width: auto;
+	font-weight: normal;
+}


### PR DESCRIPTION
**Changes Introduced in [AC-6732](https://masschallenge.atlassian.net/browse/AC-6732):**
- Added program family labels to sub nav items

**Test:**
Load the latest clean DB
`make load-remote-db`

_On development_
1. Login as `demoadmin@masschallenge.org`
2. Visit http://localhost:8181/admin/simpleuser/user/73848/change/
3. Grant the user the `2019 Finalist (Boston)` role
4. Visit http://localhost:8181/dashboard/boston-finalist/bos-session-slides/
5. Notice the sub nav doesn't match the attachment on the ticket.

_checkout this branch_
- Follow instructions from 1-4 above, and notice that now it looks similar except without the labels
- Visit http://localhost:8181/admin/simpleuser/user/73848/change/
- Grant the user the `2019 Finalist (IL)` role
- Visit http://localhost:8181/dashboard/boston-finalist/bos-session-slides/
- Notice now that it really matches the attachment.

Sibling PR: https://github.com/masschallenge/accelerate/pull/2236