### PR TITLE
AC 7521: View Office Hours Reservation modal

### DIFF
--- a/src/themes/masschallenge/collections/grid.overrides
+++ b/src/themes/masschallenge/collections/grid.overrides
@@ -66,3 +66,8 @@
 .ui.zero-margin.grid {
   margin: 0;
 }
+
+.ui.grid > .row.link-row:hover {
+  background: @lightGray;
+  cursor: pointer
+}

--- a/src/themes/masschallenge/elements/label.overrides
+++ b/src/themes/masschallenge/elements/label.overrides
@@ -16,6 +16,10 @@
   }
 }
 
+ui.label.tiny {
+  fontsize: 10px;
+}
+
 .ui.dark.label{
   background: @darkPrimaryColor;
   color: @whiteColor;

--- a/src/themes/masschallenge/elements/label.overrides
+++ b/src/themes/masschallenge/elements/label.overrides
@@ -16,9 +16,7 @@
   }
 }
 
-ui.label.tiny {
-  fontsize: 10px;
-}
+
 
 .ui.dark.label{
   background: @darkPrimaryColor;


### PR DESCRIPTION
## Changes made to [AC 7521](https://masschallenge.atlassian.net/browse/AC-7521)

**Changes introduced**
- View Office Hours Reservation modal

**Testing**
- As a mentor with the ability to reserve office hours, go to [http://localhost:8181/newofficehour] or [on test4](https://test4.masschallenge.org/newofficehour/)
- Create a new `office hour`
- Masquerade as a Finalist in the same program as the mentor who created the office hour
- Go to  to [http://localhost:8181/newofficehour] or [on test4](https://test4.masschallenge.org/newofficehour/) and reserve the newly created office hour
- Masquerade back as a mentor and click to see the reserved office hour

Confirm this PR meets the definition of done according to [AC 7521](https://masschallenge.atlassian.net/browse/AC-7521)
[Linked to](https://github.com/masschallenge/accelerate/pull/2652)