### PR TITLE
[AC-8351]: Upgrade lodash.template to version 4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3503,12 +3503,12 @@
       },
       "dependencies": {
         "lodash.template": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-          "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+          "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0",
+            "lodash._reinterpolate": "^3.0.0",
             "lodash.templatesettings": "^4.0.0"
           }
         },
@@ -3694,12 +3694,12 @@
           "dev": true
         },
         "lodash.template": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-          "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+          "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0",
+            "lodash._reinterpolate": "^3.0.0",
             "lodash.templatesettings": "^4.0.0"
           }
         },
@@ -3970,6 +3970,25 @@
         "vinyl": "^0.5.0"
       },
       "dependencies": {
+        "lodash.template": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+          "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "^3.0.0",
+            "lodash.templatesettings": "^4.0.0"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+          "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "^3.0.0"
+          }
+        },
         "object-assign": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
@@ -5046,18 +5065,6 @@
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
-    "lodash._basetostring": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-      "dev": true
-    },
-    "lodash._basevalues": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-      "dev": true
-    },
     "lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
@@ -5117,12 +5124,6 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
-    "lodash._root": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-      "dev": true
-    },
     "lodash._shimkeys": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
@@ -5163,15 +5164,6 @@
       "requires": {
         "lodash.assign": "^3.0.0",
         "lodash.restparam": "^3.0.0"
-      }
-    },
-    "lodash.escape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true,
-      "requires": {
-        "lodash._root": "^3.0.0"
       }
     },
     "lodash.flatten": {
@@ -5235,33 +5227,6 @@
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
-    },
-    "lodash.template": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0"
-      }
     },
     "lodash.uniq": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "resolutions": {
     "graceful-fs": "^4.2.4",
-    "diff": "3.5.0"
+    "diff": "3.5.0",
+    "lodash.template": "4.5.0"
   },
   "devDependencies": {
     "semantic-ui": "^2.4.1",


### PR DESCRIPTION
## [AC-8351](https://masschallenge.atlassian.net/browse/AC-8351)

**Changes introduced**
- Upgrade lodash.template to version 4.5.0

**Testing**
- On this branch, `npm install`
- Confirm `lodash.template` is upgraded to version 4.5.0
- Confirm that semantic-ui-theme works as expected